### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please note: for opening solution in VS2010 you should have *Microsoft Visual St
 The solution includes Winform application - AR.Drone.WinApp, it provides minimalistic interface 
 for controling and displaying video from the AR.Drone 2.0.
 
-##Contributions
+## Contributions
 ```Avionics.Autopilot``` module by [Yury Rozhdestvensky](https://github.com/yur) from [robodem.com](http://robodem.com).  
 
 ##License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
